### PR TITLE
fix: Cannot read property 'retry-after' of undefined

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -213,8 +213,7 @@ function onError(err: AxiosError) {
     // If enabled, check for 'Retry-After' header in response to use as delay
     if (
       config.checkRetryAfter &&
-      err.response &&
-      err.response.headers['retry-after']
+      err.response?.headers?.['retry-after']
     ) {
       const retryAfter = parseRetryAfter(err.response.headers['retry-after']);
       if (retryAfter && retryAfter > 0 && retryAfter <= config.maxRetryAfter!) {


### PR DESCRIPTION
Fixes the new 'retry-after' feature so that it does not cause an error when an error response is processed which does not contain a `headers` property.